### PR TITLE
Associate volume with loops

### DIFF
--- a/bot_server.py
+++ b/bot_server.py
@@ -339,6 +339,7 @@ class LoopBot:
             'talking':    self.streaming,
             'device_in':  self.dev_in,
             'device_out': self.dev_out,
+            'volume':     self.playback_volume,
             'user_counts': user_counts,
             'talkers':    talkers,
         }


### PR DESCRIPTION
## Summary
- track volume per loop on the server side
- send volume to bots when they join loops
- expose volumes via `/api/status`
- update UI slider range and refresh logic
- include current volume in `/status` response

## Testing
- `python -m py_compile bot_server.py web_ui_server.py config_dialog.py start_all.py`

------
https://chatgpt.com/codex/tasks/task_e_6854723c064883288f6664747df43379