### PR TITLE
Associate volume with loops

### DIFF
--- a/bot_server.py
+++ b/bot_server.py
@@ -101,7 +101,7 @@ class LoopBot:
         self.streaming = False          # True if currently "talking"
         self.status    = "Starting…"
         self._recv_q   = queue.Queue()  # queue for received PCM audio
-        self.playback_volume = 1.0      # Output volume (0.0-1.0)
+        self.playback_volume = 1.0      # Output volume (0.0-2.0)
         self._connect_mumble()          # connect to Mumble server
         self._start_mic_stream()        # start microphone input stream
         self._start_playback_thread()   # start thread for playback
@@ -287,9 +287,9 @@ class LoopBot:
 
     def set_volume(self, vol):
         """
-        Set playback volume (0.0-1.0).
+        Set playback volume (0.0-2.0).
         """
-        self.playback_volume = max(0.0, min(1.0, float(vol)))
+        self.playback_volume = max(0.0, min(2.0, float(vol)))
 
     def _update_user_map(self):
         channel_users = {}
@@ -339,6 +339,7 @@ class LoopBot:
             'talking':    self.streaming,
             'device_in':  self.dev_in,
             'device_out': self.dev_out,
+            'volume':     self.playback_volume,
             'user_counts': user_counts,
             'talkers':    talkers,
         }


### PR DESCRIPTION
## Summary
- track volume per loop on the server side
- send volume to bots when they join loops
- expose volumes via `/api/status`
- update UI slider range and refresh logic
- include current volume in `/status` response
- allow amplification up to 2x

## Testing
- `python -m py_compile bot_server.py web_ui_server.py config_dialog.py start_all.py`

------
https://chatgpt.com/codex/tasks/task_e_6854723c064883288f6664747df43379