### PR TITLE
Fix delay playback when talking

### DIFF
--- a/bot_server.py
+++ b/bot_server.py
@@ -274,6 +274,12 @@ class LoopBot:
     def talk(self):
         self.streaming = True
         self.status    = f"Talk → {self.loop or 'Root'}"
+        if self.audio_delay_enabled:
+            while not self.audio_delay_queue.empty():
+                try:
+                    self.audio_delay_queue.get_nowait()
+                except Exception:
+                    break
 
     def mute(self):
         self.streaming = False


### PR DESCRIPTION
## Summary
- flush buffered audio when starting to talk so pre-talk content isn't played

## Testing
- `python -m py_compile bot_server.py web_ui_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68781f131e20832882146e4e64452855