### PR TITLE
Add password option for Mumble server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Run the main script:
 python start_all.py
 ```
 On the first launch, a configuration web page will open automatically. Enter the
-Mumble server address, port, bot base name and choose your role. When you submit
+Mumble server address, port, optional server password, bot base name and choose your role. When you submit
 that page a `run_config.json` file is created and the application will continue
 running.
 

--- a/bot_server.py
+++ b/bot_server.py
@@ -74,11 +74,13 @@ parser.add_argument("--bot-name", required=True)
 parser.add_argument("--api-port", required=True, type=int)
 parser.add_argument("--server", required=True)
 parser.add_argument("--port", required=True, type=int)
+parser.add_argument("--password", default="")
 args = parser.parse_args()
 
 SERVER = args.server
 PORT   = args.port
 USER   = args.bot_name
+PASSWORD = args.password
 
 certfile, keyfile = ensure_bot_cert(USER)
 
@@ -172,6 +174,7 @@ class LoopBot:
     def _connect_mumble(self):
         self.client = Mumble(
             SERVER, USER, port=PORT, reconnect=True,
+            password=(PASSWORD or None),
             certfile=certfile, keyfile=keyfile,
         )
         self.client.callbacks.set_callback(PYMUMBLE_CLBK_USERUPDATED,  lambda u,e: self._update_user_map())

--- a/config_dialog.py
+++ b/config_dialog.py
@@ -19,11 +19,12 @@ def read_config():
     return None
 
 
-def write_config(server, port, bot_base, role):
+def write_config(server, port, password, bot_base, role):
     with open(CONFIG_FILE, "w") as f:
         json.dump({
             "server": server,
             "port": port,
+            "password": password,
             "bot_base": bot_base,
             "role": role,
         }, f)

--- a/run_config.json
+++ b/run_config.json
@@ -1,1 +1,7 @@
-{"server": "127.0.0.1", "port": 64738, "bot_base": "ELLA", "role": "AA"}
+{
+  "server": "127.0.0.1",
+  "port": 64738,
+  "password": "",
+  "bot_base": "ELLA",
+  "role": "AA"
+}

--- a/start_all.py
+++ b/start_all.py
@@ -15,12 +15,17 @@ config = get_config_from_dialog()
 SERVER = config['server']
 PORT = config['port']
 BOT_BASE = config['bot_base']
+PASSWORD = config.get('password', '')
 
 bots = [
     [sys.executable, os.path.join(DIR, "bot_server.py"), "--server", SERVER, "--port", str(PORT), "--bot-name", f"{BOT_BASE}", "--api-port", "6001"],
     [sys.executable, os.path.join(DIR, "bot_server.py"), "--server", SERVER, "--port", str(PORT), "--bot-name", f"{BOT_BASE}1", "--api-port", "6002"],
     [sys.executable, os.path.join(DIR, "bot_server.py"), "--server", SERVER, "--port", str(PORT), "--bot-name", f"{BOT_BASE}2", "--api-port", "6003"]
 ]
+
+if PASSWORD:
+    for cmd in bots:
+        cmd.extend(["--password", PASSWORD])
 
 procs = []
 for cmd in bots:

--- a/web_ui_server.py
+++ b/web_ui_server.py
@@ -135,6 +135,7 @@ CONFIG_HTML = f"""
   <h2>Mission Control Setup</h2>
   <label>Server<input id='srv'></label>
   <label>Port<input id='prt' type='number'></label>
+  <label>Password<input id='pwd' type='password'></label>
   <label>Bot Base<input id='bot'></label>
   <label>Role <select id='role'>{options}</select></label>
   <button id='save'>Save</button>
@@ -143,6 +144,7 @@ CONFIG_HTML = f"""
    const cfg = await (await fetch('/api/get_config')).json();
    document.getElementById('srv').value  = cfg.server   || '';
    document.getElementById('prt').value  = cfg.port     || '';
+   document.getElementById('pwd').value  = cfg.password || '';
    document.getElementById('bot').value  = cfg.bot_base || '';
    document.getElementById('role').value = cfg.role     || 'FLIGHT';
  }}
@@ -150,6 +152,7 @@ CONFIG_HTML = f"""
    const cfg = {{
      server:  document.getElementById('srv').value,
      port:    +document.getElementById('prt').value,
+    password:document.getElementById('pwd').value,
      bot_base:document.getElementById('bot').value,
      role:    document.getElementById('role').value
    }};


### PR DESCRIPTION
## Summary
- allow optional password to be set in `run_config.json`
- propagate password through config UI, `start_all.py` and bot launch
- support `--password` in `bot_server.py`
- document new field in README

## Testing
- `python -m py_compile start_all.py bot_server.py config_dialog.py web_ui_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68853baa779483288db6802b691f7a4f